### PR TITLE
Fix code scanning alert no. 3: Overly permissive file permissions

### DIFF
--- a/resources/tests/test_workspace.py
+++ b/resources/tests/test_workspace.py
@@ -38,7 +38,7 @@ def ssh_connection() -> str:
     with open(setup_ssh_file, "w") as f:
         f.write(r.text)
     # make the file executable for the user
-    os.chmod(setup_ssh_file, 0o744)
+    os.chmod(setup_ssh_file, 0o700)
 
     # Todo: Remove usage of pexpect when ssh setup script callable non-interactively
     import pexpect


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/ml-workspace/security/code-scanning/3](https://github.com/khulnasoft/ml-workspace/security/code-scanning/3)

To fix the problem, we need to restrict the file permissions to ensure that only the owner can read, write, and execute the file. This can be achieved by changing the permissions from `0o744` to `0o700`. This change will ensure that the file is not accessible by other users, thus mitigating the security risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Restrict file permissions from 0o744 to 0o700 to address a security vulnerability by ensuring only the file owner can read, write, and execute the file.